### PR TITLE
Make code not be escaped because otherwise it renders escaped

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,3 @@ xcuserdata
 .svn
 CVS
 node_modules
-lib

--- a/examples/index.js
+++ b/examples/index.js
@@ -14,14 +14,18 @@ const App = () => md({ h1: 'h2' })`
 This is some text <span style=${{ fontWeight: 'bold' }}> we _here_ </span>
 
 This is more text. And some more. And more.
-\`\`\`jsx
-let x = alpha
-function xyz(){
 
+What happens if I want to say 5 > 4?
+
+\`\`\`swift
+func test(_ text: String) -> String {
+    return "hello there: \\\\(text)"
 }
 \`\`\`
 
 here's some \`inline code\`
+
+some inline Swift maybe \`func hello(name: String) -> String {\`
 
 ${'I interpolated some text here'}
 

--- a/lib/babel.js
+++ b/lib/babel.js
@@ -1,0 +1,138 @@
+'use strict';
+
+var _package = require('../package.json');
+
+var _babylon = require('babylon');
+
+var babylon = _interopRequireWildcard(_babylon);
+
+var _commonmark = require('commonmark');
+
+var _commonmark2 = _interopRequireDefault(_commonmark);
+
+var _jsx = require('./jsx');
+
+var _jsx2 = _interopRequireDefault(_jsx);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
+
+module.exports = {
+  visitor: {
+    Program: {
+      enter: function enter(path) {
+        var libName = void 0;
+        path.traverse({
+          ImportDeclaration: function ImportDeclaration(path) {
+            if (path.node.source.value === _package.name) {
+              var specifiers = path.get('specifiers');
+              var _iteratorNormalCompletion = true;
+              var _didIteratorError = false;
+              var _iteratorError = undefined;
+
+              try {
+                for (var _iterator = specifiers[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+                  var specifier = _step.value;
+
+                  if (specifier.isImportDefaultSpecifier()) {
+                    libName = specifier.node.local.name;
+                    break;
+                  } else if (specifier.isImportSpecifier() && specifier.node.imported.name === 'default') {
+                    libName = specifier.node.local.name;
+                    break;
+                  }
+                }
+              } catch (err) {
+                _didIteratorError = true;
+                _iteratorError = err;
+              } finally {
+                try {
+                  if (!_iteratorNormalCompletion && _iterator.return) {
+                    _iterator.return();
+                  }
+                } finally {
+                  if (_didIteratorError) {
+                    throw _iteratorError;
+                  }
+                }
+              }
+            }
+          },
+          CallExpression: function CallExpression(path) {
+            if (!path.get('callee').isIdentifier() || path.node.callee.name !== 'require') {
+              return;
+            }
+            var args = path.get('arguments');
+            var arg = args[0];
+            if (!arg || !arg.isStringLiteral() || arg.node.value !== _package.name) {
+              return;
+            }
+            var parent = path.parentPath();
+            if (parent.isVariableDeclarator()) {
+              var id = parent.get('id');
+              if (id.isIdentifier()) {
+                libName = id.name;
+              }
+            } else if (parent.isAssignmentExpression()) {
+              var _id = parent.get('left');
+              if (_id.isIdentifier()) {
+                libName = _id.name;
+              }
+            }
+          }
+        });
+
+        if (!libName) {
+          // the module is not required in this file.
+          return;
+        }
+
+        path.traverse({
+          TaggedTemplateExpression: function TaggedTemplateExpression(path) {
+
+            var code = path.hub.file.code;
+            var tagName = path.node.tag.name;
+            if (path.node.tag.type === 'CallExpression') {
+              tagName = path.node.tag.callee.name;
+            }
+
+            if (tagName === libName) {
+              (function () {
+                var reader = new _commonmark2.default.Parser();
+                var writer = new _jsx2.default();
+                var stubs = path.node.quasi.expressions.map(function (x) {
+                  return code.substring(x.start, x.end);
+                });
+                var stubCtx = stubs.reduce(function (o, stub, i) {
+                  return o['spur-' + i] = stub, o;
+                }, {});
+                var ctr = 0;
+                var strs = path.node.quasi.quasis.map(function (x) {
+                  return x.value.cooked;
+                });
+                var src = strs.reduce(function (arr, str, i) {
+                  arr.push(str);
+                  if (i !== stubs.length) {
+                    arr.push('spur-' + ctr++);
+                  }
+                  return arr;
+                }, []).join('');
+                var parsed = reader.parse(src);
+                var intermediateSrc = writer.render(parsed);
+                // replace with stubs
+                var newSrc = intermediateSrc.replace(/spur\-[0-9]+/gm, function (x) {
+                  return '{' + stubCtx[x] + '}';
+                });
+                var transformed = babylon.parse(tagName + '(' + (path.node.tag.type === 'CallExpression' ? code.substring(path.node.tag.arguments[0].start, path.node.tag.arguments[0].end) + ', ' : '') + '_m_ => <div className=\'_markdown_\'>' + newSrc + '</div>)', { plugins: ['*']
+                });
+                path.replaceWith(transformed.program.body[0]);
+              })();
+            }
+          }
+        });
+      }
+    }
+
+  }
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,26 @@
+'use strict';
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+var markdown = function markdown(o, fn) {
+  if (o.length >= 0 && o.raw || fn && fn.length && fn.raw) {
+    throw new Error('you forgot to add \'markdown-in-js/babel\' to your babel plugins');
+  }
+  if (typeof o === 'function') {
+    return markdown({}, o);
+  }
+  if (!fn) {
+    return function (nextFn) {
+      return markdown(o, nextFn);
+    };
+  }
+  if (typeof fn === 'function') {
+    return fn(_extends({
+      'br': 'br', 'a': 'a', 'img': 'img', 'em': 'em', 'strong': 'strong', 'p': 'p',
+      'h1': 'h1', 'h2': 'h2', 'h3': 'h3', 'h4': 'h4', 'h5': 'h5', 'h6': 'h6',
+      'code': 'code', 'pre': 'pre', 'hr': 'hr', 'blockquote': 'blockquote',
+      'ul': 'ul', 'ol': 'ol', 'li': 'li' }, o));
+  }
+};
+
+module.exports = markdown;

--- a/lib/jsx.js
+++ b/lib/jsx.js
@@ -1,0 +1,317 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = undefined;
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _renderer = require('./renderer');
+
+var _renderer2 = _interopRequireDefault(_renderer);
+
+var _common = require('commonmark/lib/common');
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var reUnsafeProtocol = /^javascript:|vbscript:|file:|data:/i;
+var reSafeDataProtocol = /^data:image\/(?:png|gif|jpeg|webp)/i;
+
+var potentiallyUnsafe = function potentiallyUnsafe(url) {
+  return reUnsafeProtocol.test(url) && !reSafeDataProtocol.test(url);
+};
+
+var JSXRenderer = function (_Renderer) {
+  _inherits(JSXRenderer, _Renderer);
+
+  function JSXRenderer(options) {
+    _classCallCheck(this, JSXRenderer);
+
+    var _this = _possibleConstructorReturn(this, (JSXRenderer.__proto__ || Object.getPrototypeOf(JSXRenderer)).call(this, options));
+
+    options = options || {};
+    // by default, soft breaks are rendered as newlines in HTML
+    options.softbreak = options.softbreak || '\n';
+    // set to "<br />" to make them hard breaks
+    // set to " " if you want to ignore line wrapping in source
+
+    _this.disableTags = 0;
+    _this.lastOut = '\n';
+    _this.options = options;
+    return _this;
+  }
+
+  _createClass(JSXRenderer, [{
+    key: 'tag',
+    value: function tag(name, attrs, selfclosing) {
+      if (this.disableTags > 0) {
+        return;
+      }
+      this.buffer += '<' + name;
+      if (attrs && attrs.length > 0) {
+        var i = 0;
+        var attrib = void 0;
+        while ((attrib = attrs[i]) !== undefined) {
+          this.buffer += ' ' + attrib[0] + '="' + attrib[1] + '"';
+          i++;
+        }
+      }
+      if (selfclosing) {
+        this.buffer += ' /';
+      }
+      this.buffer += '>';
+      this.lastOut = '>';
+    }
+
+    /* Node methods */
+
+  }, {
+    key: 'text',
+    value: function text(node) {
+      this.codeAwareOut(node.literal, false);
+    }
+  }, {
+    key: 'softbreak',
+    value: function softbreak() {
+      this.lit(this.options.softbreak);
+    }
+  }, {
+    key: 'linebreak',
+    value: function linebreak() {
+      this.tag('_m_.br', [], true);
+      this.cr();
+    }
+  }, {
+    key: 'link',
+    value: function link(node, entering) {
+      var attrs = this.attrs(node);
+      if (entering) {
+        if (!(this.options.safe && potentiallyUnsafe(node.destination))) {
+          attrs.push(['href', (0, _common.escapeXml)(node.destination, true)]);
+        }
+        if (node.title) {
+          attrs.push(['title', (0, _common.escapeXml)(node.title, true)]);
+        }
+        this.tag('_m_.a', attrs);
+      } else {
+        this.tag('/_m_.a');
+      }
+    }
+  }, {
+    key: 'image',
+    value: function image(node, entering) {
+      if (entering) {
+        if (this.disableTags === 0) {
+          if (this.options.safe && potentiallyUnsafe(node.destination)) {
+            this.lit('<_m_.img src="" alt="');
+          } else {
+            this.lit('<_m_.img src="' + (0, _common.escapeXml)(node.destination, true) + '" alt="');
+          }
+        }
+        this.disableTags += 1;
+      } else {
+        this.disableTags -= 1;
+        if (this.disableTags === 0) {
+          if (node.title) {
+            this.lit('" title="' + (0, _common.escapeXml)(node.title, true));
+          }
+          this.lit('" />');
+        }
+      }
+    }
+  }, {
+    key: 'emph',
+    value: function emph(node, entering) {
+      this.tag(entering ? '_m_.em' : '/_m_.em');
+    }
+  }, {
+    key: 'strong',
+    value: function strong(node, entering) {
+      this.tag(entering ? '_m_.strong' : '/_m_.strong');
+    }
+  }, {
+    key: 'paragraph',
+    value: function paragraph(node, entering) {
+      var grandparent = node.parent.parent,
+          attrs = this.attrs(node);
+      if (grandparent !== null && grandparent.type === 'list') {
+        if (grandparent.listTight) {
+          return;
+        }
+      }
+      if (entering) {
+        this.cr();
+        this.tag('_m_.p', attrs);
+      } else {
+        this.tag('/_m_.p');
+        this.cr();
+      }
+    }
+  }, {
+    key: 'heading',
+    value: function heading(node, entering) {
+      var tagname = '_m_.h' + node.level,
+          attrs = this.attrs(node);
+      if (entering) {
+        this.cr();
+        this.tag(tagname, attrs);
+      } else {
+        this.tag('/' + tagname);
+        this.cr();
+      }
+    }
+  }, {
+    key: 'code',
+    value: function code(node) {
+      this.tag('_m_.code');
+      this.codeAwareOut('{`' + node.literal + '`}', true);
+      this.tag('/_m_.code');
+    }
+  }, {
+    key: 'code_block',
+    value: function code_block(node) {
+
+      var info_words = node.info ? node.info.split(/\s+/) : [],
+          attrs = this.attrs(node);
+      if (info_words.length > 0 && info_words[0].length > 0) {
+        attrs.push(['className', 'language-' + (0, _common.escapeXml)(info_words[0], true)]);
+      }
+      this.cr();
+      this.tag('_m_.pre');
+      this.tag('_m_.code', attrs);
+      this.codeAwareOut('{`' + node.literal + '`}', true);
+      this.tag('/_m_.code');
+      this.tag('/_m_.pre');
+      this.cr();
+    }
+  }, {
+    key: 'thematic_break',
+    value: function thematic_break(node) {
+      var attrs = this.attrs(node);
+      this.cr();
+      this.tag('_m_.hr', attrs, true);
+      this.cr();
+    }
+  }, {
+    key: 'block_quote',
+    value: function block_quote(node, entering) {
+      var attrs = this.attrs(node);
+      if (entering) {
+        this.cr();
+        this.tag('_m_.blockquote', attrs);
+        this.cr();
+      } else {
+        this.cr();
+        this.tag('/_m_.blockquote');
+        this.cr();
+      }
+    }
+  }, {
+    key: 'list',
+    value: function list(node, entering) {
+      var tagname = node.listType === 'bullet' ? 'ul' : 'ol',
+          attrs = this.attrs(node);
+
+      if (entering) {
+        var start = node.listStart;
+        if (start !== null && start !== 1) {
+          attrs.push(['start', start.toString()]);
+        }
+        this.cr();
+        this.tag('_m_.' + tagname, attrs);
+        this.cr();
+      } else {
+        this.cr();
+        this.tag('/_m_.' + tagname);
+        this.cr();
+      }
+    }
+  }, {
+    key: 'item',
+    value: function item(node, entering) {
+      var attrs = this.attrs(node);
+      if (entering) {
+        this.tag('_m_.li', attrs);
+      } else {
+        this.tag('/_m_.li');
+        this.cr();
+      }
+    }
+  }, {
+    key: 'html_inline',
+    value: function html_inline(node) {
+      if (this.options.safe) {
+        this.lit('<!-- raw HTML omitted -->');
+      } else {
+        this.lit(node.literal);
+      }
+    }
+  }, {
+    key: 'html_block',
+    value: function html_block(node) {
+      this.cr();
+      if (this.options.safe) {
+        this.lit('<!-- raw HTML omitted -->');
+      } else {
+        this.lit(node.literal);
+      }
+      this.cr();
+    }
+  }, {
+    key: 'custom_inline',
+    value: function custom_inline(node, entering) {
+      if (entering && node.onEnter) {
+        this.lit(node.onEnter);
+      } else if (!entering && node.onExit) {
+        this.lit(node.onExit);
+      }
+    }
+  }, {
+    key: 'custom_block',
+    value: function custom_block(node, entering) {
+      this.cr();
+      if (entering && node.onEnter) {
+        this.lit(node.onEnter);
+      } else if (!entering && node.onExit) {
+        this.lit(node.onExit);
+      }
+      this.cr();
+    }
+
+    /* Helper methods */
+
+  }, {
+    key: 'codeAwareOut',
+    value: function codeAwareOut(s, isCode) {
+      isCode ? this.out(s) : this.out((0, _common.escapeXml)(s, false));
+    }
+  }, {
+    key: 'out',
+    value: function out(s) {
+      this.lit(s);
+    }
+  }, {
+    key: 'attrs',
+    value: function attrs(node) {
+      var att = [];
+      if (this.options.sourcepos) {
+        var pos = node.sourcepos;
+        if (pos) {
+          att.push(['data-sourcepos', String(pos[0][0]) + ':' + String(pos[0][1]) + '-' + String(pos[1][0]) + ':' + String(pos[1][1])]);
+        }
+      }
+      return att;
+    }
+  }]);
+
+  return JSXRenderer;
+}(_renderer2.default);
+
+exports.default = JSXRenderer;

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1,0 +1,75 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+var Renderer = function () {
+  function Renderer() {
+    _classCallCheck(this, Renderer);
+  }
+
+  _createClass(Renderer, [{
+    key: 'render',
+    value: function render(ast) {
+      var walker = ast.walker(),
+          event = void 0,
+          type = void 0;
+
+      this.buffer = '';
+      this.lastOut = '\n';
+
+      while (event = walker.next()) {
+        type = event.node.type;
+        if (this[type]) {
+          this[type](event.node, event.entering);
+        } else {
+          // console.log('missed', event.node.type)
+        }
+      }
+      return this.buffer;
+    }
+
+    /**
+     *  Concatenate a literal string to the buffer.
+     *
+     *  @param str {String} The string to concatenate.
+     */
+
+  }, {
+    key: 'lit',
+    value: function lit(str) {
+      this.buffer += str;
+      this.lastOut = str;
+    }
+  }, {
+    key: 'cr',
+    value: function cr() {
+      if (this.lastOut !== '\n') {
+        this.lit('\n');
+      }
+    }
+
+    /**
+     *  Concatenate a string to the buffer possibly escaping the content.
+     *
+     *  Concrete renderer implementations should override this method.
+     *
+     *  @param str {String} The string to concatenate.
+     */
+
+  }, {
+    key: 'out',
+    value: function out(str) {
+      this.lit(str);
+    }
+  }]);
+
+  return Renderer;
+}();
+
+exports.default = Renderer;

--- a/src/jsx.js
+++ b/src/jsx.js
@@ -48,7 +48,7 @@ export default class JSXRenderer extends Renderer {
   /* Node methods */
 
   text(node) {
-    this.out(node.literal)
+    this.codeAwareOut(node.literal, false)
   }
 
   softbreak() {
@@ -137,7 +137,7 @@ export default class JSXRenderer extends Renderer {
 
   code(node) {
     this.tag('_m_.code')
-    this.out(node.literal)
+    this.codeAwareOut(`{\`${node.literal}\`}`, true)
     this.tag('/_m_.code')
   }
 
@@ -151,7 +151,7 @@ export default class JSXRenderer extends Renderer {
     this.cr()
     this.tag('_m_.pre')
     this.tag('_m_.code', attrs)
-    this.out(`{\`${node.literal}\`}`)
+    this.codeAwareOut(`{\`${node.literal}\`}`, true)
     this.tag('/_m_.code')
     this.tag('/_m_.pre')
     this.cr()
@@ -244,8 +244,12 @@ export default class JSXRenderer extends Renderer {
 
   /* Helper methods */
 
+  codeAwareOut(s, isCode) {
+    isCode ? this.out(s) : this.out(esc(s, false))
+  }
+
   out(s) {
-    this.lit(esc(s, false))
+    this.lit(s)
   }
 
   attrs(node) {


### PR DESCRIPTION
Having code blocks go through the `esc(s, false)` call made them have escaped characters output into the resulting `<pre><code>...</code></pre>` HTML blocks, e.g.

```
\`\`\`swift
func testing() -> String {
  return "hello"
}
\`\`\`
```

would result in

```swift
func testing() -&gt; String {
  return "hello"
}
```