### PR TITLE
Don't escape `code block` content

### DIFF
--- a/examples/index.js
+++ b/examples/index.js
@@ -17,11 +17,11 @@ This is more text. And some more. And more.
 \`\`\`jsx
 let x = alpha
 function xyz(){
-
+  console.log("xyz")
 }
 \`\`\`
 
-here's some \`inline code\`
+here's some \`"inline code"\`
 
 ${'I interpolated some text here'}
 

--- a/src/jsx.js
+++ b/src/jsx.js
@@ -151,7 +151,7 @@ export default class JSXRenderer extends Renderer {
     this.cr()
     this.tag('_m_.pre')
     this.tag('_m_.code', attrs)
-    this.out(`{\`${node.literal}\`}`)
+    this.lit(`{\`${node.literal}\`}`, false)
     this.tag('/_m_.code')
     this.tag('/_m_.pre')
     this.cr()


### PR DESCRIPTION
### What

Don't escape `code block` content.

```js
console.log("meow") // should keep the quotes
```