### PR TITLE
Fix use of path.parentPath

### DIFF
--- a/src/babel.js
+++ b/src/babel.js
@@ -37,7 +37,7 @@ module.exports = () => {
               if (!arg || !arg.isStringLiteral() || arg.node.value !== packageName) {
                 return
               }
-              const parent = path.parentPath()
+              const parent = path.parentPath
               if (parent.isVariableDeclarator()) {
                 const id = parent.get('id')
                 if (id.isIdentifier()) {


### PR DESCRIPTION
Currently, Babel throws an exception when importing this library with `require`:

`path.parentPath is not a function`

This PR fixes that by changing `path.parentPath()` -> `path.parentPath` 🙂 